### PR TITLE
Register Process

### DIFF
--- a/lib/todo_server.ex
+++ b/lib/todo_server.ex
@@ -45,14 +45,19 @@ end
 
 defmodule TodoServer do
   ### Client functions ###
-  def start, do: spawn(fn -> loop(TodoList.new()) end)
+  def start do
+    spawn(fn ->
+      Process.register(self(), :todo_server)
+      loop(TodoList.new())
+    end)
+  end
 
-  def add_entry(server_pid, entry), do: send(server_pid, {:new_entry, entry})
+  def add_entry(entry), do: send(:todo_server, {:new_entry, entry})
 
-  def delete_entry(server_pid, entry_id), do: send(server_pid, {:delete_entry, entry_id})
+  def delete_entry(entry_id), do: send(:todo_server, {:delete_entry, entry_id})
 
-  def entries(server_pid, date) do
-    send(server_pid, {:entries, self(), date})
+  def entries(date) do
+    send(:todo_server, {:entries, self(), date})
 
     receive do
       {:response, entries} -> entries


### PR DESCRIPTION
### Registering a process

By registering the server process with a name (i.e. `:todo_server`), the client functions no longer have to pass around the server pid when sending messages to the server process. This simplifies the interface e.g. 

this ...

```elixir
iex> server_pid = TodoServer.start()
iex> TodoServer.add_entry(server_pid, %{date: ~D[2024-02-02], title: "first entry"})
iex> TodoServer.add_entry(server_pid, %{date: ~D[2024-02-02], title: "second entry"})
iex> TodoServer.entries(server_pid, ~D[2024-02-02])

[
  %{id: 1, date: ~D[2024-02-02]},
  %{id: 2, date: ~D[2024-02-02]},
]
```


becomes this...

```elixir
iex> TodoServer.start()
iex> TodoServer.add_entry(%{date: ~D[2024-02-02], title: "first entry"})
iex> TodoServer.add_entry(%{date: ~D[2024-02-02], title: "second entry"})
iex> TodoServer.entries(~D[2024-02-02])

[
  %{id: 1, date: ~D[2024-02-02]},
  %{id: 2, date: ~D[2024-02-02]},
]
```

### Rules for naming/registering processes
1. Name must be an atom.
2. A process can only have one name.
3. Two processes can't have the same name.