### PR TITLE
Fix: remove forgotten function

### DIFF
--- a/lib/server_process.ex
+++ b/lib/server_process.ex
@@ -22,8 +22,6 @@ defmodule ServerProcess do
     end
   end
 
-  def update_state(server_pid, message), do: send(server_pid, {:message, self(), message})
-
   ### Server functions ###
   defp loop(callback_module, current_state) do
     receive do


### PR DESCRIPTION
I forgot the remove the `update_state` function as part of https://github.com/Primebrook/elixir-concurrency/pull/3.
