### PR TITLE
Asynchronous Server Requests

### DIFF
--- a/lib/server_process.ex
+++ b/lib/server_process.ex
@@ -1,6 +1,6 @@
 defmodule ServerProcess do
   @moduledoc """
-  An implementation for a generic server process - designed for plugin to another
+  An implementation for a generic server process - designed for plugin to other
   module (callback module) 
   """
 
@@ -13,7 +13,7 @@ defmodule ServerProcess do
   end
 
   def call(server_pid, message) do
-    send(server_pid, {message, self()})
+    send(server_pid, {:call, message, self()})
 
     receive do
       {:response, response} -> response
@@ -22,36 +22,21 @@ defmodule ServerProcess do
     end
   end
 
+  def cast(server_pid, message), do: send(server_pid, {:cast, message, self()})
+
   ### Server functions ###
   defp loop(callback_module, current_state) do
     receive do
-      {message, caller_pid} ->
+      {:call, message, caller_pid} ->
         {response, new_state} = callback_module.handle_call(message, current_state)
         send(caller_pid, {:response, response})
 
         loop(callback_module, new_state)
+
+      {:cast, message, _caller_pid} ->
+        new_state = callback_module.handle_cast(message, current_state)
+
+        loop(callback_module, new_state)
     end
   end
-end
-
-defmodule KeyValueStore do
-  @moduledoc """
-  The KeyValueStore callback module. This will be running in the server process.
-
-  Recall the callback process must implement: init/0 and handle_call/2 - these  are both callback functions
-  used internally by the generic server process code. 
-
-  In contrast, we implement the interface functions: start/0, get/2 and put/3 so that the client never has
-  to know about the ServerProcess module.
-  """
-  def start, do: ServerProcess.start(__MODULE__)
-
-  def init, do: %{}
-
-  def put(server_pid, key, value), do: ServerProcess.call(server_pid, {:put, key, value})
-
-  def get(server_pid, key), do: ServerProcess.call(server_pid, {:get, key})
-
-  def handle_call({:put, key, value}, state), do: {:ok, Map.put(state, key, value)}
-  def handle_call({:get, key}, state), do: {Map.get(state, key), state}
 end

--- a/lib/server_process/key_value_store.ex
+++ b/lib/server_process/key_value_store.ex
@@ -1,0 +1,24 @@
+defmodule ServerProcess.KeyValueStore do
+  @moduledoc """
+  The KeyValueStore callback module. This will be running in the server process.
+
+  Recall the callback process must implement: init/0 and handle_call/2 - these  are both callback functions
+  used internally by the generic server process code. 
+
+  In contrast, we implement the interface functions: start/0, get/2 and put/3 so that the client never has
+  to know about the ServerProcess module.
+  """
+  alias ServerProcess
+
+  def start, do: ServerProcess.start(__MODULE__)
+
+  def init, do: %{}
+
+  def put(server_pid, key, value), do: ServerProcess.cast(server_pid, {:put, key, value})
+
+  def get(server_pid, key), do: ServerProcess.call(server_pid, {:get, key})
+
+  def handle_call({:get, key}, state), do: {Map.get(state, key), state}
+
+  def handle_cast({:put, key, value}, state), do: Map.put(state, key, value)
+end


### PR DESCRIPTION
Following https://github.com/Primebrook/elixir-concurrency/pull/3/files we now add asynchronous server requests (i.e. 'fire-and-forget' requests). We use the OTP convention of "cast" to make the request. The client doesn't wait for a response from the server hence it's the client is not blocked and free to continue about it's business after sending the request.

We make the `put` the async request - the `get` needs to be synchronous since we the client requires a response.


I separate out the ServerProcess into a separate file.
