### PR TITLE
GenServer implementations

### DIFF
--- a/lib/gen_server/key_value_store.ex
+++ b/lib/gen_server/key_value_store.ex
@@ -1,0 +1,31 @@
+defmodule GenServer.KeyValueStore do
+  @moduledoc """
+  The KeyValueStore callback module. This will be running in the server process.
+
+  Recall the callback process must implement: init/0 and handle_call/2 - these  are both callback functions
+  used internally by the generic server process code. 
+
+  In contrast, we implement the interface functions: start/0, get/2 and put/3 so that the client never has
+  to know about the ServerProcess module.
+  """
+  use GenServer
+
+  def start, do: GenServer.start(__MODULE__, nil, name: __MODULE__)
+
+  @impl GenServer
+  def init(_initial_state), do: {:ok, %{}}
+
+  def put(key, value), do: GenServer.cast(__MODULE__, {:put, key, value})
+
+  def get(key), do: GenServer.call(__MODULE__, {:get, key})
+
+  @impl GenServer
+  def handle_call({:get, key}, _caller, state) do
+    {:reply, Map.get(state, key), state}
+  end
+
+  @impl GenServer
+  def handle_cast({:put, key, value}, state) do
+    {:noreply, Map.put(state, key, value)}
+  end
+end

--- a/lib/gen_server/key_value_store.ex
+++ b/lib/gen_server/key_value_store.ex
@@ -1,12 +1,6 @@
 defmodule GenServer.KeyValueStore do
   @moduledoc """
-  The KeyValueStore callback module. This will be running in the server process.
-
-  Recall the callback process must implement: init/0 and handle_call/2 - these  are both callback functions
-  used internally by the generic server process code. 
-
-  In contrast, we implement the interface functions: start/0, get/2 and put/3 so that the client never has
-  to know about the ServerProcess module.
+  The KeyValueStore callback module.
   """
   use GenServer
 

--- a/lib/gen_server/todo_server.ex
+++ b/lib/gen_server/todo_server.ex
@@ -1,0 +1,27 @@
+defmodule GenServer.TodoServer do
+  @moduledoc """
+  The TodoServer - the non-generic code responsible for maintaining,
+  the todo list which exists on the server process.
+  """
+
+  use GenServer
+  alias TodoList
+
+  def start, do: GenServer.start(__MODULE__, nil, name: __MODULE__)
+
+  @impl GenServer
+  def init(_initial_state), do: {:ok, TodoList.new()}
+
+  def put(entry), do: GenServer.cast(__MODULE__, {:add_entry, entry})
+  def get(date), do: GenServer.call(__MODULE__, {:get_entries, date})
+
+  @impl GenServer
+  def handle_cast({:add_entry, entry}, todo_list) do
+    {:noreply, TodoList.add_entry(todo_list, entry)}
+  end
+
+  @impl GenServer
+  def handle_call({:get_entries, date}, _caller, todo_list) do
+    {:reply, TodoList.entries(todo_list, date), todo_list}
+  end
+end


### PR DESCRIPTION
We move over from the manually written ServerProcess to the builtin OTP compliant `GenServer`.

We add the TodoServer and KeyValueStore as GenServers.


GenServer define behaviours which the callback modules must implement:

1. `init/1` and it must return: `{:ok, initial_state}`
2. `handle_call/3` and it must return: `{:reply, response, new_state}`
3. `handle_cast/2` and it return: `{:noreply, new_state}`
